### PR TITLE
Template updates for Terraform 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Template for Terraform repos for MIT Libraries.
 
 After deploying this, the following steps must be completed.
 
-1. Update the `terraform { }` block in `main.tf`. We now use the `cloud {}` block to link to workspaces in Terraform Cloud. The very first thing to do is set the correct tags in the `workspaces {}` block.
-1. Update `main.tf` to include any additional Terraform Provider(s).
-1. Update the `terraform { required_providers { } }` block in `versions.tf` to set the location and constraints on the additional providers.
-1. **Optional**: Update the `locals {}` block in `main.tf` to provide a project-id.
-1. Copy the `locals {}` block from the `deleteme.tf` file and paste it into each `.tf` file that will create named resources.
-1. Delete the `deleteme.tf` file.
+1. Update the `terraform { }` block in [main.tf](./main.tf). We now use the `cloud {}` block to link to workspaces in Terraform Cloud. The very first thing to do is set the correct tags in the `workspaces {}` block.
+1. Update [main.tf](./main.tf) to include any additional Terraform Provider(s).
+1. Update the `terraform { required_providers { } }` block in [versions.tf](./versions.tf) to set the location and constraints on the additional providers.
+1. **Optional**: Update the `locals {}` block in [main.tf](./main.tf) to provide a project-id.
+1. **Optional**: Update the `tags {}` block in [providers.tf](./providers.tf) to enable a backup plan via AWS Backups
+1. Copy the `locals {}` block from the [deleteme.tf](./deleteme.tf) file and paste it into each `.tf` file that will create named resources.
+1. Delete the [deleteme.tf](./deleteme.tf) file.
 1. Delete the file tree below.
 
 ## File Tree
@@ -21,11 +22,14 @@ After deploying this, the following steps must be completed.
 ├── deleteme.tf
 ├── docs
 │   └── adrs
-│       └── 0001-record-architecture-decisions.md
+│       ├── 0001-record-architecture-decisions.md
+│       └── 0002-upgrade-to-cloud-block.md
 ├── main.tf
 ├── modules
 │   └── README.md
 ├── providers.tf
+├── ssm_inputs.tf
+├── ssm_outputs.tf
 ├── tests
 │   └── README.md
 ├── variables.tf
@@ -39,12 +43,14 @@ After deploying this, the following steps must be completed.
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 1.1 |
+| terraform | ~> 1.2 |
 | aws | ~> 3.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| aws | ~> 3.0 |
 
 ## Modules
 
@@ -52,7 +58,9 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,3 @@
+# Files README
+
+This is where any files used by Terraform should be stored.

--- a/main.tf
+++ b/main.tf
@@ -25,3 +25,6 @@ terraform {
 locals {
   project_id = null # change to "project-id-name" if this is part of a larger project
 }
+
+# Capture the AWS account number and capture the default managed key for SSM in KMS
+data "aws_caller_identity" "current" {}

--- a/providers.tf
+++ b/providers.tf
@@ -8,6 +8,8 @@
 # in main.tf.
 # Optional tags are in comments below:
 #  app-repo   = "name of GitHub repo for app that depends on this infrastructure"
+#  backup_enabled = true/false (determines if AWS Backup backs up tagged resources)
+#  backup_type = "local_30" || "local_14" || "local_7" || "remote_30" || "remote_14" (pick one, see mitlib-tf-workloads-awsbackups for details)
 
 
 provider "aws" {
@@ -19,7 +21,7 @@ provider "aws" {
       environment  = var.environment
       ou           = var.ou
       terraform    = "true"
-      infra-repo   = "mitlib-tf-${var.name}"
+      infra-repo   = "mitlib-tf-${var.ou}-${var.name}"
       contains-pii = "false"
     }
   }

--- a/ssm_inputs.tf
+++ b/ssm_inputs.tf
@@ -1,0 +1,34 @@
+################################################################################
+# This is used to simplify the SSM Parameter inputs
+locals {
+  vpc_vars  = "/tfvars/vpc"
+  r53_vars  = "/tfvars/r53"
+  init_vars = "/tfvars/init"
+}
+
+### We do additional checks for user-inputted values including:
+### 1. Checking for trailing/leading spaces in the SSM parameters (we expect none)
+### 2. Outputting them if they are not securestrings so that we can check them in tfc
+
+## Each aws_ssm_parameter data object needs a brief description of the value stored
+##  in the parameter (Type & Datatype refer to settings in AWS, Format refers to 
+##  what Terraform thinks the value is). 
+## We do additional checks for user-inputted values including:
+##  1. Checking for trailing/leading spaces in the SSM parameters (we expect none)
+##  2. Outputting them if they are not securestrings so that we can check them in tfc
+## The general format of an input from SSM Parameter Store should look like:
+#
+# # Type:string  Datatype:test  Format:string
+# data "aws_ssm_parameter" "name_of_parameter" {
+#   name = "${var.tfinput_ssm_path}/name-of-parameter"
+#   lifecycle {
+#     postcondition {
+#       condition     = trimspace(self.value) == self.value
+#       error_message = "There is a leading or trailing blank space."
+#     }
+#   }
+# }
+# # Output user set ssm parameters for clarity of plans and applies
+# output "name_of_parameter" {
+#   value = data.aws_ssm_parameter.name_of_parameter.type == "SecureString" ? "Suppressed: SecureString" : nonsensitive(data.aws_ssm_parameter.name_of_parameter.value)
+# }

--- a/ssm_outputs.tf
+++ b/ssm_outputs.tf
@@ -1,0 +1,15 @@
+# Output
+# Each aws_ssm_parameter resource object needs a brief description of the value stored
+#  in the parameter (Type & Datatype refer to settings in AWS, format refers to 
+#  what Terraform thinks the value is). The general form of an output to SSM Parameter
+#  Store should look like:
+#
+# # Type:string  Datatype:test  Format:string
+# resource "aws_ssm_parameter" "name_of_parameter" {
+#   #checkov:skip=CKV2_AWS_34:By default we are not encrypting parameters in tfoutput_ssm_path
+#   type        = "String"
+#   name        = "${var.tfoutput_ssm_path}/name-of-parameter"
+#   value       = < the parameter value >
+#   description = "Description of the parameter value"
+#   overwrite   = true
+# }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@
 # Providers themselves are set in the `providers.tf` file.
 
 terraform {
-  required_version = "~> 1.1"
+  required_version = "~> 1.2"
 
   required_providers {
     aws = {


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

Add ssm_input and ssm_output examples, including the new ssm_input validation technique. It also updates the version constraint for Terraform to ~> 1.2.

#### Helpful background context

In order for us to use the new precondition/postcondition features for validating resources, we need to set the minimum Terraform version to 1.2. We also needed a few more bits of sample code to help infra engineers get started with new repos.

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
