### PR TITLE
Fixes for AWS Backup

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -8,8 +8,13 @@
 # in main.tf.
 # Optional tags are in comments below:
 #  app-repo   = "name of GitHub repo for app that depends on this infrastructure"
-#  backup_enabled = true/false (determines if AWS Backup backs up tagged resources)
-#  backup_type = "local_30" || "local_14" || "local_7" || "remote_30" || "remote_14" (pick one, see mitlib-tf-workloads-awsbackups for details)
+#  backup_enable = true/false (determines if AWS Backup backs up tagged resources)
+#  backup_type = "local" || "remote" (determines if AWS Backup copies the recovery 
+#                                     point to a separate AWS Account)
+#  backup_length = "7" || "14" || "30" (determines retention period for recovery 
+#                                       points)
+# These values can be set here and they will apply to all resources created by this
+# repo. Or, these can be set as additional tags on individual resources.
 
 
 provider "aws" {


### PR DESCRIPTION
#### Developer Checklist

- [ ] The README contains any additional info needed outside of the terraform docs generated
- [ ] Any special variables have values configured in AWS SSM
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

* Update comment in `providers.tf` with the correct tags and tag values for enabling auto-backups via AWS Backup

#### Helpful background context

The final version of tagging used by [mitlib-tf-workloads-awsbackups](https://github.com/MITLibraries/mitlib-tf-workloads-awsbackups) is set. It uses three tags (`backup_enable`, `backup_type`, and `backup_length`). These are now properly listed here in a comment in the `providers.tf` file.

#### What are the relevant tickets?

* https://mitlibraries.atlassian.net/browse/IN-387
* https://mitlibraries.atlassian.net/browse/IN-522

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

NO
