### PR TITLE
Hashicorp AWS Provider [hashicorp/aws] Upgrade to Major Version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ After deploying this, the following steps must be completed.
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.2 |
-| aws | ~> 4.0 |
+| aws | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 4.0 |
+| aws | ~> 5.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains any additional info needed outside of the terraform docs generated
- [X] Any special variables have values configured in AWS SSM
- [X] Stakeholder approval has been confirmed (or is not needed)

#### What does this PR do?

This PR upgrades the HashiCorp AWS provider to major version 5.

How this addresses that need:
* Updates required_providers in the versions.tf file
* Updates the README.md documentation file

#### Helpful background context

This AWS provider upgrade will prevent us from having to manually upgrade new repositories to hashicorp/aws v5.

Note: I have also written code that moves this template to pre-commit hooks. I intend to push it up shortly and create a PR for it. The move to pre-commit hooks will prevent us from having to manually make that change in new repositories. Using pre-commit hooks in all our repositories will improve the cleanliness and legibility of our commit histories.

#### Requires Database Migrations?

NO

#### Includes new or updated dependencies?

YES

This PR upgrades the hashicorp/aws provider to major version 5.x.
